### PR TITLE
INTEGRATION [PR#122 > development/3.1] Bump @types/node from 16.11.14 to 17.0.32

### DIFF
--- a/package.json
+++ b/package.json
@@ -33,7 +33,7 @@
     "axios": "^0.24.0"
   },
   "devDependencies": {
-    "@types/node": "^16.10.5",
+    "@types/node": "^17.0.32",
     "@typescript-eslint/parser": "^5.0.0",
     "@vercel/ncc": "^0.31.1",
     "eslint": "^7.32.0",

--- a/yarn.lock
+++ b/yarn.lock
@@ -751,15 +751,10 @@
   resolved "https://registry.yarnpkg.com/@types/json5/-/json5-0.0.29.tgz#ee28707ae94e11d2b827bcbe5270bcea7f3e71ee"
   integrity sha1-7ihweulOEdK4J7y+UnC86n8+ce4=
 
-"@types/node@*":
-  version "17.0.0"
-  resolved "https://registry.yarnpkg.com/@types/node/-/node-17.0.0.tgz#62797cee3b8b497f6547503b2312254d4fe3c2bb"
-  integrity sha512-eMhwJXc931Ihh4tkU+Y7GiLzT/y/DBNpNtr4yU9O2w3SYBsr9NaOPhQlLKRmoWtI54uNwuo0IOUFQjVOTZYRvw==
-
-"@types/node@^16.10.5":
-  version "16.11.14"
-  resolved "https://registry.yarnpkg.com/@types/node/-/node-16.11.14.tgz#4939fb42e5b0ffb3ea7e193c28244fe7414977a6"
-  integrity sha512-mK6BKLpL0bG6v2CxHbm0ed6RcZrAtTHBTd/ZpnlVPVa3HkumsqLE4BC4u6TQ8D7pnrRbOU0am6epuALs+Ncnzw==
+"@types/node@*", "@types/node@^17.0.32":
+  version "17.0.32"
+  resolved "https://registry.yarnpkg.com/@types/node/-/node-17.0.32.tgz#51d59d7a90ef2d0ae961791e0900cad2393a0149"
+  integrity sha512-eAIcfAvhf/BkHcf4pkLJ7ECpBAhh9kcxRBpip9cTiO+hf+aJrsxYxBeS6OXvOd9WqNAJmavXVpZvY1rBjNsXmw==
 
 "@types/prettier@^2.1.5":
   version "2.4.2"


### PR DESCRIPTION
This pull request has been created automatically.
It is linked to its parent pull request #122.

**Do not edit this pull request directly.**
If you need to amend/cancel the changeset on branch
`w/3.1/dependabot/npm_and_yarn/types/node-17.0.32`, please follow this
procedure:

```bash
 $ git fetch
 $ git checkout w/3.1/dependabot/npm_and_yarn/types/node-17.0.32
 $ # <amend or cancel the changeset by _adding_ new commits>
 $ git push origin w/3.1/dependabot/npm_and_yarn/types/node-17.0.32
```

Please always comment pull request #122 instead of this one.