### PR TITLE
Bugfix/RELENG-6497_fix_sha1_in_artifact_name

### DIFF
--- a/.eslintrc.json
+++ b/.eslintrc.json
@@ -47,7 +47,8 @@
     "semi": "off",
     "@typescript-eslint/semi": ["error", "never"],
     "@typescript-eslint/type-annotation-spacing": "error",
-    "@typescript-eslint/unbound-method": "error"
+    "@typescript-eslint/unbound-method": "error",
+    "sort-imports": "off"
   },
   "env": {
     "node": true,

--- a/src/artifacts.ts
+++ b/src/artifacts.ts
@@ -4,6 +4,7 @@ import * as path from 'path'
 import * as process from 'process'
 import {
   artifactsRetry,
+  getCommitSha1,
   workflowRunResponseDataType,
   workflowRunResponseType
 } from './utils'
@@ -26,7 +27,7 @@ export async function artifactsName(): Promise<string> {
   const owner: string = github.context.repo.owner
   const repo: string = github.context.repo.repo
   const workflow: string = await workflowName()
-  const commit: string = github.context.sha.slice(0, 10)
+  const commit: string = getCommitSha1('HEAD').slice(0, 10)
   const runNumber: number = github.context.runNumber
 
   return `github:${owner}:${repo}:staging-${commit}.${workflow}.${runNumber}`

--- a/src/artifacts.ts
+++ b/src/artifacts.ts
@@ -27,7 +27,11 @@ export async function artifactsName(): Promise<string> {
   const owner: string = github.context.repo.owner
   const repo: string = github.context.repo.repo
   const workflow: string = await workflowName()
-  const commit: string = await getCommitSha1('HEAD').slice(0, 10)
+  const commit: string = await getCommitSha1('HEAD').then(
+    (value) => {
+      return value.slice(0, 10)
+    }
+  )
   const runNumber: number = github.context.runNumber
 
   return `github:${owner}:${repo}:staging-${commit}.${workflow}.${runNumber}`
@@ -36,7 +40,11 @@ export async function artifactsName(): Promise<string> {
 export async function artifactsPatternName(workflow: string): Promise<string> {
   const owner: string = github.context.repo.owner
   const repo: string = github.context.repo.repo
-  const commit: string = github.context.sha.slice(0, 10)
+  const commit: string = await getCommitSha1('HEAD').then(
+    (value) => {
+      return value.slice(0, 10)
+    }
+  )
   workflow = await workflowName(workflow)
 
   return `github:${owner}:${repo}:staging-${commit}.${workflow}`

--- a/src/artifacts.ts
+++ b/src/artifacts.ts
@@ -27,11 +27,7 @@ export async function artifactsName(): Promise<string> {
   const owner: string = github.context.repo.owner
   const repo: string = github.context.repo.repo
   const workflow: string = await workflowName()
-  const commit: string = await getCommitSha1('HEAD').then(
-    (value) => {
-      return value.slice(0, 10)
-    }
-  )
+  const commit: string = (await getCommitSha1('HEAD')).slice(0, 10)
   const runNumber: number = github.context.runNumber
 
   return `github:${owner}:${repo}:staging-${commit}.${workflow}.${runNumber}`
@@ -40,11 +36,7 @@ export async function artifactsName(): Promise<string> {
 export async function artifactsPatternName(workflow: string): Promise<string> {
   const owner: string = github.context.repo.owner
   const repo: string = github.context.repo.repo
-  const commit: string = await getCommitSha1('HEAD').then(
-    (value) => {
-      return value.slice(0, 10)
-    }
-  )
+  const commit: string = (await getCommitSha1('HEAD')).slice(0, 10)
   workflow = await workflowName(workflow)
 
   return `github:${owner}:${repo}:staging-${commit}.${workflow}`

--- a/src/artifacts.ts
+++ b/src/artifacts.ts
@@ -27,7 +27,7 @@ export async function artifactsName(): Promise<string> {
   const owner: string = github.context.repo.owner
   const repo: string = github.context.repo.repo
   const workflow: string = await workflowName()
-  const commit: string = getCommitSha1('HEAD').slice(0, 10)
+  const commit: string = await getCommitSha1('HEAD').slice(0, 10)
   const runNumber: number = github.context.runNumber
 
   return `github:${owner}:${repo}:staging-${commit}.${workflow}.${runNumber}`

--- a/src/methods.ts
+++ b/src/methods.ts
@@ -14,10 +14,7 @@ import {
 
 import axios, {AxiosInstance, AxiosRequestConfig, AxiosResponse} from 'axios'
 import {InputsArtifacts} from './inputs-helper'
-import {
-  artifactsRetry,
-  getCommitSha1,
-} from './utils'
+import {artifactsRetry, getCommitSha1} from './utils'
 import async from 'async'
 import fs from 'fs'
 import https from 'https'
@@ -54,7 +51,7 @@ export async function promote(inputs: InputsArtifacts): Promise<void> {
     )
   }
 
-  let myOutput = await getCommitSha1(inputs.tag)
+  const myOutput = await getCommitSha1(inputs.tag)
   if (!myOutput.includes(artifacts_commit))
     throw Error(
       `Tag commit ${artifacts_commit} don't match the artifacts commit ${myOutput}`

--- a/src/methods.ts
+++ b/src/methods.ts
@@ -1,7 +1,12 @@
 import * as core from '@actions/core'
 import * as glob from '@actions/glob'
+import async from 'async'
+import axios, {AxiosInstance, AxiosRequestConfig, AxiosResponse} from 'axios'
+import fs from 'fs'
+import https from 'https'
 import * as path from 'path'
 import * as process from 'process'
+
 import {
   artifactsName,
   artifactsPatternName,
@@ -11,13 +16,8 @@ import {
   setNotice,
   setOutputs
 } from './artifacts'
-
-import axios, {AxiosInstance, AxiosRequestConfig, AxiosResponse} from 'axios'
-import {artifactsRetry, getCommitSha1} from './utils'
 import {InputsArtifacts} from './inputs-helper'
-import async from 'async'
-import fs from 'fs'
-import https from 'https'
+import {artifactsRetry, getCommitSha1} from './utils'
 
 export async function setup(inputs: InputsArtifacts): Promise<void> {
   const name: string = await artifactsName()

--- a/src/methods.ts
+++ b/src/methods.ts
@@ -1,5 +1,4 @@
 import * as core from '@actions/core'
-import * as exec from '@actions/exec'
 import * as glob from '@actions/glob'
 import * as path from 'path'
 import * as process from 'process'
@@ -55,7 +54,7 @@ export async function promote(inputs: InputsArtifacts): Promise<void> {
     )
   }
 
-  myOutput = getCommitSha1(inputs.tag)
+  let myOutput = getCommitSha1(inputs.tag)
   if (!myOutput.includes(artifacts_commit))
     throw Error(
       `Tag commit ${artifacts_commit} don't match the artifacts commit ${myOutput}`

--- a/src/methods.ts
+++ b/src/methods.ts
@@ -1,7 +1,7 @@
 import * as core from '@actions/core'
 import * as glob from '@actions/glob'
 import async from 'async'
-import axios, {AxiosInstance, AxiosRequestConfig, AxiosResponse} from 'axios'
+import axios, { AxiosInstance, AxiosRequestConfig, AxiosResponse } from 'axios'
 import fs from 'fs'
 import https from 'https'
 import * as path from 'path'
@@ -16,8 +16,8 @@ import {
   setNotice,
   setOutputs
 } from './artifacts'
-import {InputsArtifacts} from './inputs-helper'
-import {artifactsRetry, getCommitSha1} from './utils'
+import { InputsArtifacts } from './inputs-helper'
+import { artifactsRetry, getCommitSha1 } from './utils'
 
 export async function setup(inputs: InputsArtifacts): Promise<void> {
   const name: string = await artifactsName()

--- a/src/methods.ts
+++ b/src/methods.ts
@@ -13,8 +13,8 @@ import {
 } from './artifacts'
 
 import axios, {AxiosInstance, AxiosRequestConfig, AxiosResponse} from 'axios'
-import {InputsArtifacts} from './inputs-helper'
 import {artifactsRetry, getCommitSha1} from './utils'
+import {InputsArtifacts} from './inputs-helper'
 import async from 'async'
 import fs from 'fs'
 import https from 'https'

--- a/src/methods.ts
+++ b/src/methods.ts
@@ -46,7 +46,7 @@ export async function promote(inputs: InputsArtifacts): Promise<void> {
   } else if (promoted_match !== null) {
     core.info('Promoted artifacts has been selected')
     const artifacts_tag = promoted_match[2]
-    artifacts_commit = getCommitSha1(artifacts_tag)
+    artifacts_commit = await getCommitSha1(artifacts_tag)
     artifacts_prefix = promoted_match[1]
   } else {
     throw Error(
@@ -54,7 +54,7 @@ export async function promote(inputs: InputsArtifacts): Promise<void> {
     )
   }
 
-  let myOutput = getCommitSha1(inputs.tag)
+  let myOutput = await getCommitSha1(inputs.tag)
   if (!myOutput.includes(artifacts_commit))
     throw Error(
       `Tag commit ${artifacts_commit} don't match the artifacts commit ${myOutput}`

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -71,7 +71,7 @@ export function artifactsRetry(
   })
 }
 
-export async function getCommitSha1(revspec: string): string {
+export async function getCommitSha1(revspec: string): Promise<string> {
   let output = ''
   
   const options: exec.ExecOptions = {}

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -69,3 +69,17 @@ export function artifactsRetry(
     return Promise.reject(error)
   })
 }
+
+export function getCommitSha1(revspec: string): string {
+  let output = ''
+  
+  const options: exec.ExecOptions = {}
+  options.listeners = {
+    stdout: (data: Buffer) => {
+      output += data.toString()
+    }
+  }
+
+  await exec.exec('git', ['rev-list', '-n', '1', revspec], options)
+  return output
+}

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -71,7 +71,7 @@ export function artifactsRetry(
   })
 }
 
-export function getCommitSha1(revspec: string): string {
+export async function getCommitSha1(revspec: string): string {
   let output = ''
   
   const options: exec.ExecOptions = {}

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -1,4 +1,5 @@
 import * as core from '@actions/core'
+import * as exec from '@actions/exec'
 import {AxiosError, AxiosInstance, AxiosRequestConfig, AxiosStatic} from 'axios'
 import {
   GetResponseDataTypeFromEndpointMethod,


### PR DESCRIPTION
When setting artifact name get the currently checked out commit sha1 from the HEAD, not from the github context, because it can be from a different commit when triggering a workflow from a different branch or when the workflow checkout the repository at differnt commit/tag/branch.