### PR TITLE
upgrade to node16

### DIFF
--- a/action.yaml
+++ b/action.yaml
@@ -67,6 +67,6 @@ outputs:
       The full url in which artifacts will be stored.
     value: ${{ steps.artifacts.outputs.link }}
 runs:
-  using: 'node12'
+  using: 'node16'
   main: 'dist/index.js'
   post: 'dist/index.js'


### PR DESCRIPTION
Upgrade the action so it uses node16.

Node12 has been deprecated since April 2022.
See GitHub post about upgrading to node16:

https://github.blog/changelog/2022-09-22-github-actions-all-actions-will-begin-running-on-node16-instead-of-node12/