### PR TITLE
ci: bump actions/checkout to v6 and update artifacts image

### DIFF
--- a/.github/workflows/check-dist.yml
+++ b/.github/workflows/check-dist.yml
@@ -14,7 +14,7 @@ jobs:
     runs-on: ubuntu-latest
 
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v6
 
       - name: Set Node.js 16.x
         uses: actions/setup-node@v4.0.3

--- a/.github/workflows/promote-release.yaml
+++ b/.github/workflows/promote-release.yaml
@@ -13,7 +13,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
     - name: Checkout repo
-      uses: actions/checkout@v3
+      uses: actions/checkout@v6
 
     - name: Get the artifacts name of workflow test-get
       uses: ./

--- a/.github/workflows/share-artifacts.yaml
+++ b/.github/workflows/share-artifacts.yaml
@@ -14,7 +14,7 @@ jobs:
       artifacts-link: ${{ steps.artifacts.outputs.link }}
     steps:
     - name: Checkout
-      uses: actions/checkout@v3
+      uses: actions/checkout@v6
     - name: artifacts upload
       id: artifacts
       uses: ./
@@ -30,7 +30,7 @@ jobs:
     needs: build
     steps:
     - name: Checkout
-      uses: actions/checkout@v3
+      uses: actions/checkout@v6
     - name: Retrieve file
       run: |
         curl -u ${{ secrets.ARTIFACTS_USER }}:${{ secrets.ARTIFACTS_PASSWORD }} ${{ needs.build.outputs.artifacts-link }}/action.yaml -o /tmp/action.yaml

--- a/.github/workflows/test-errors.yaml
+++ b/.github/workflows/test-errors.yaml
@@ -14,7 +14,7 @@ jobs:
     runs-on: ubuntu-latest
     environment: ${{ inputs.environment || 'production' }}
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v6
       - name: Push all files
         id: artifacts-test
         continue-on-error: true
@@ -33,7 +33,7 @@ jobs:
     runs-on: ubuntu-latest
     environment: ${{ inputs.environment || 'production' }}
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v6
       - name: Push all files
         id: artifacts-test
         continue-on-error: true
@@ -51,7 +51,7 @@ jobs:
   wrong-host:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v6
       - name: Push all files
         id: artifacts-test
         continue-on-error: true

--- a/.github/workflows/test-get.yaml
+++ b/.github/workflows/test-get.yaml
@@ -14,7 +14,7 @@ jobs:
     environment: ${{ inputs.environment || 'production' }}
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v6
       - run: echo -n "SUCCESSFUL" > .final_status
       - name: Artifacts Upload
         id: artifacts-upload
@@ -40,7 +40,7 @@ jobs:
     container:
       image: 'ubuntu:20.04'
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v6
       - name: update
         run: apt-get update
       - run: apt-get install -y curl
@@ -64,7 +64,7 @@ jobs:
     runs-on: ubuntu-latest
     environment: ${{ inputs.environment || 'production' }}
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v6
       - name: Get Artifacts
         id: artifacts-get
         uses: ./

--- a/.github/workflows/test-index.yaml
+++ b/.github/workflows/test-index.yaml
@@ -29,7 +29,7 @@ jobs:
       sha: ${{ steps.index.outputs.sha }}
       actor: ${{ steps.index.outputs.actor }}
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v6
       - name: Setup final status file
         run: echo -n SUCCESSFUL > .final_status
       - name: Push final status

--- a/.github/workflows/test-load.yaml
+++ b/.github/workflows/test-load.yaml
@@ -33,7 +33,7 @@ jobs:
     container: ${{ matrix.test.container }}
     name: load tests on ${{ matrix.test.name }}
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v6
       - name: create multiple files
         run: |
           mkdir -p artifacts/${{ matrix.test.name }}

--- a/.github/workflows/test-prolong.yaml
+++ b/.github/workflows/test-prolong.yaml
@@ -14,7 +14,7 @@ jobs:
     runs-on: ubuntu-latest
     environment: ${{ inputs.environment || 'production' }}
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v6
       - run: echo -n SUCCESSFUL > .final_status
       - name: Artifacts Upload
         id: artifacts-upload

--- a/.github/workflows/test-promote.yaml
+++ b/.github/workflows/test-promote.yaml
@@ -21,7 +21,7 @@ jobs:
         ports:
         - 8080:8000
       artifacts:
-        image: "registry.scality.com/artifacts/artifacts:4.2.6"
+        image: "ghcr.io/scality/artifacts:4.3.3"
         ports:
           - 8000:80
         env:
@@ -52,7 +52,7 @@ jobs:
           AWS_ACCESS_KEY_ID: accessKey1
           AWS_BUCKET_PREFIX: artifacts
           ENDPOINT_URL: http://localhost:8080
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v6
       - run: echo SUCCESS > .final_status
       - name: Artifacts Upload
         id: artifacts-upload

--- a/.github/workflows/test-pull-request.yaml
+++ b/.github/workflows/test-pull-request.yaml
@@ -8,7 +8,7 @@ jobs:
     runs-on: ubuntu-latest
     environment: production
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v6
       - name: create file to upload
         run: |
           mkdir -p artifacts

--- a/.github/workflows/test-setup.yaml
+++ b/.github/workflows/test-setup.yaml
@@ -14,7 +14,7 @@ jobs:
     runs-on: ubuntu-latest
     environment: ${{ inputs.environment || 'production' }}
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v6
       - name: Artifacts Setup
         id: artifacts-setup
         uses: ./

--- a/.github/workflows/test-upload.yaml
+++ b/.github/workflows/test-upload.yaml
@@ -14,7 +14,7 @@ jobs:
     environment: ${{ inputs.environment || 'production' }}
     name: A job that pushes a lot of files on artifacts
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v6
       - name: create multiple files
         run: mkdir -p test-files && for i in {1..2000}; do dd if=/dev/random of=test-files/$i.txt count=1 bs=1M; done
       - name: Push all files
@@ -32,7 +32,7 @@ jobs:
     container: ubuntu
     name: Upload multiple files inside from a container job
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v6
       - name: create multiple files
         run: mkdir -p test-files && for i in {1..2000}; do dd if=/dev/random of=test-files/$i.txt count=1 bs=1M; done
         shell: bash
@@ -50,7 +50,7 @@ jobs:
     environment: ${{ inputs.environment || 'production' }}
     name: A job that push a big file on artifacts
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v6
       - name: create one big file
         run: dd if=/dev/random of=big_file.txt count=1024 bs=1M
       - name: Push on big file
@@ -73,7 +73,7 @@ jobs:
     name: A job that push single files on artifacts
     needs: [test-upload-big-file, test-upload-multiple-files]
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v6
       - id: artifacts-upload
         uses: ./
         with:
@@ -114,7 +114,7 @@ jobs:
     environment: ${{ inputs.environment || 'production' }}
     name: A job that try to push an empty folder
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v6
       - run: mkdir -p artifacts
       - name: Push all files
         uses: ./

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -22,7 +22,7 @@ jobs:
         ports:
         - 8000:8000
       artifacts:
-        image: "registry.scality.com/artifacts/artifacts:4.2.6"
+        image: "ghcr.io/scality/artifacts:4.3.3"
         ports:
           - 8080:80
         env:
@@ -35,7 +35,7 @@ jobs:
           GITHUB_API_ENABLED: true
           GITHUB_USER_ALLOWED_UPLOAD: ${{ secrets.ARTIFACTS_USER }}
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v6
       - name: Set Node.js
         uses: actions/setup-node@v4.0.3
         with:


### PR DESCRIPTION
## Summary

- Bump `actions/checkout` from v3/v4 to v6 across all 13 workflow files
- Update the artifacts container image from `registry.scality.com/artifacts/artifacts:4.2.6` to `ghcr.io/scality/artifacts:4.3.3` in `test.yml` and `test-promote.yaml`

No code changes. Intended to be merged before [#576](https://github.com/scality/action-artifacts/pull/576) so that PR can rebase cleanly with only the multipart upload changes on top.

## Test plan

- [ ] CI passes on this PR
- [ ] After merge, rebase PR #576 onto main

🤖 Generated with [Claude Code](https://claude.com/claude-code)